### PR TITLE
fix [comment 组件]添加 replyShowSize 参数时回复不正确显示

### DIFF
--- a/packages/src/components/comment/src/comment.vue
+++ b/packages/src/components/comment/src/comment.vue
@@ -158,7 +158,7 @@ const replyBoxParam: InjectReplyBoxApi = {
   replyPage: (parentId, pageNum, pageSize, finish) => {
     emit('replyPage', { parentId, pageNum, pageSize, finish })
   },
-  replyShowSize: isNull(replyShowSize, 3),
+  replyShowSize: isNull(replyShowSize?.value, 3),
   comments: comments
 }
 provide(InjectReplyBox, replyBoxParam)

--- a/packages/src/components/comment/src/reply-box.vue
+++ b/packages/src/components/comment/src/reply-box.vue
@@ -79,7 +79,7 @@ const data = computed(() => {
     data.list = tmp
   }
   if (page) {
-    data.list = data.list.slice(0, 5)
+    data.list = data.list.slice(0, state.pageSize)
   }
   return data
 })


### PR DESCRIPTION
添加 replyShowSize 参数后 isNull 返回的是代理对象，会导致下面代码错误。
```
  if (!state.over) {
    let tmp = data.list.slice(0, replyShowSize)
    data.list = tmp
  }
```